### PR TITLE
Add files via upload

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,11 @@
   },
   "waitFor": "onCreateCommand",
   "updateContentCommand": "python3 -m pip install -r requirements.txt",
-  "postCreateCommand": "",
+  "postCreateCommand": "pip3 install -U layoutparser",
+  "postCreateCommand": "pip install layoutparser[effdet]"
+  "postCreateCommand": "pip install layoutparser torchvision && pip install "git+https://github.com/facebookresearch/detectron2.git@v0.5#egg=detectron2""
+  "postCreateCommand": "pip install layoutparser[paddledetection]"
+  "postCreateCommand": "pip3 install -U layoutparser[ocr]",
   "customizations": {
     "codespaces": {
       "openFiles": []

--- a/.devcontainer/layoutparserex.py
+++ b/.devcontainer/layoutparserex.py
@@ -1,0 +1,17 @@
+import layoutparser as lp
+import cv2
+image = cv2.imread("C:/Users/julia/Downloads/temp.jpg")
+    #temp.jpg was downloaded from https://developer.ibm.com/exchanges/data/all/publaynet/
+image = image[..., ::-1]
+    # Convert the image from BGR (cv2 default loading style)
+    # to RGB
+model = lp.Detectron2LayoutModel('lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config',
+                                 extra_config=["MODEL.ROI_HEADS.SCORE_THRESH_TEST", 0.8],
+                                 label_map={0: "Text", 1: "Title", 2: "List", 3:"Table", 4:"Figure"})
+    # Load the deep layout model from the layoutparser API
+    # For all the supported model, please check the Model
+    # Zoo Page: https://layout-parser.readthedocs.io/en/latest/notes/modelzoo.html
+layout = model.detect(image)
+    # Detect the layout of the input image
+lp.draw_box(image, layout, box_width=3)
+    # Show the detected layout of the input image


### PR DESCRIPTION
I couldn’t get the Devcontainer to work exactly. The line included automatically ( “python3 -m pip install -r requirements.txt”) returns a “Python was not found” error (although I have Python on my laptop), but the line to install layoutparser does work. It can also install latoutparser[effdet] and layoutparser torchvision. There was a typo in the line to install detectron; I’ve fixed that. However, I could not install the detectron package on my computer; I got a “cannot find command ‘git’” error). The line to install layoutparser[paddledetection] works. The layoutparser[ocr] also downloaded fairly quickly. As such, when I ran the sample Python code to segment layout visually (using a test image from IBM’s PubLayNet dataset), I got an error message saying that “model layoutparser has no attribute Detectron2LayoutModel”, I.e. the issues were the result of the problems downloading Detectron2 with windows.
Apparently it’s generally very difficult to install detectron to Windows. For me, when I ran the combined torchvision and detectron installation line, I was able to install torchvision, but not detectron2. Is your computer running Mac/Linux or is it running windows? If it’s running windows, there is a patch linked on layout-parser.readthedocs.up/en/latest/notes/installation.html (the one created by @ivanpp).